### PR TITLE
Encode packed_command when sending to buffer

### DIFF
--- a/py3gearman/connection.py
+++ b/py3gearman/connection.py
@@ -185,9 +185,7 @@ class GearmanConnection(object):
         packed_data += self._outgoing_buffer
         while self._outgoing_commands:
             cmd_type, cmd_args = self._outgoing_commands.popleft()
-            # encodig. but failed on python3.
-            # packed_command = self._pack_command(cmd_type, cmd_args).encode()
-            packed_command = self._pack_command(cmd_type, cmd_args)
+            packed_command = self._pack_command(cmd_type, cmd_args).encode()
             packed_data += packed_command
 
         self._outgoing_buffer = bytes(packed_data)


### PR DESCRIPTION
I am using python 3.5.2 and uncommenting the line 138 from connnection.py was the only way to have the admin_client working and returning data as expected. Without this change every single interaction with the server using:

- send_maxqueue
- send_shutdown
- get_status
- get_version
- get_workers

will return an Exception:

```
>>> gm_admin_client.get_workers()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/py3gearman/py3gearman/admin_client.py", line 89, in get_workers
    return self.wait_until_server_responds(GEARMAN_SERVER_COMMAND_WORKERS)
  File "/py3gearman/py3gearman/admin_client.py", line 96, in wait_until_server_responds
    self.poll_connections_until_stopped([self.current_connection], continue_while_no_response, timeout=self.poll_timeout)
  File "/py3gearman/py3gearman/connection_manager.py", line 194, in poll_connections_until_stopped
    self.handle_connection_activity(read_connections, write_connections, dead_connections)
  File "/py3gearman/py3gearman/connection_manager.py", line 166, in handle_connection_activity
    self.handle_write(current_connection)
  File "/py3gearman/py3gearman/connection_manager.py", line 222, in handle_write
    current_connection.send_commands_to_buffer()
  File "/py3gearman/py3gearman/connection.py", line 191, in send_commands_to_buffer
    packed_data += bytes(packed_command)
TypeError: string argument without an encoding
```

after the change applied:

```
>>> gm_admin_client.get_workers()
({'tasks': ('process_imported_csv_data', 'categorize_products_from_imported_csv_data'), 'client_id': '-', 'file_descriptor': '33', 'ip': '::3536:3135:3500:0%3176301232'}, {'tasks': (), 'client_id': '-', 'file_descriptor': '36', 'ip': '10.58.69.1'}, {'tasks': ('code', 'admin_scheduler', 'content'), 'client_id': 'dev', 'file_descriptor': '34', 'ip': '127.0.0.1'}, {'tasks': (), 'client_id': '-', 'file_descriptor': '35', 'ip': '10.58.69.1'})
```

Hope this helps